### PR TITLE
remover tfoot

### DIFF
--- a/src/app/core/admin/alumno/list-alumnos/list-alumnos.component.html
+++ b/src/app/core/admin/alumno/list-alumnos/list-alumnos.component.html
@@ -23,16 +23,7 @@
                             <th>Acción</th>
                         </tr>
                     </thead>
-                    <tfoot>
-                        <tr>
-                            <th>Código</th>
-                            <th>Apellidos</th>
-                            <th>Nombres</th>
-                            <th>Teléfono</th>
-                            <th>Correo electrónico</th>
-                            <th>Acción</th>
-                        </tr>
-                    </tfoot>
+            
                     <tbody>
                         <tr *ngFor="let alumno of listAlumnos">
                             <td>{{alumno.alumno_codigo}}</td>


### PR DESCRIPTION
Vi innecesario el tfoot y estresante visualmente, se deberia remover en todas las tablas, puede generar confusión al usuario